### PR TITLE
Fix crash when geocoder exceeds Google Maps API usage limits

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,10 @@ History
   are on OSM, they do not return a house number, which makes addresses
   pointless.
 
+0.1.6 (2017-02-13)
+------------------
+* Fix bug with -n flag and stations
+
 0.1.5 (2017-02-13)
 ------------------
 * Add --json flag for valid JSON output

--- a/cli.py
+++ b/cli.py
@@ -147,7 +147,7 @@ def show(address, geocode, n, color, output_json):
 
     if output_json:
         click.echo(json.dumps(stations, cls=citybikes.resource.JSONEncoder,
-            indent=4))
+                              indent=4))
         return
 
     for station in stations:

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,8 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import re
 from setuptools import setup
-
-with open('cli.py', 'r') as fd:
-    version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
-                        fd.read(), re.MULTILINE).group(1)
+from cli import __version__
 
 with open('README.rst', 'r') as f:
     readme = f.read()
@@ -14,7 +11,7 @@ with open('HISTORY.rst', 'r') as f:
 
 setup(
     name='cmdbikes',
-    version=version,
+    version=__version__,
     description='Bike sharing at your terminal',
     long_description=readme + '\n\n' + history,
     author='Lluís Esquerda',


### PR DESCRIPTION
I haven't investigated further, but it happens probably due to the recent changes in Google Maps API and their usage limits. Possibly related: https://github.com/DenisCarriere/geocoder/issues/375

As a workaround, default to OSM in case of error which doesn't require an API key.